### PR TITLE
Support pagination query name configuration

### DIFF
--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -1,7 +1,9 @@
 export default {
   total: 'total',
-  page: 'page[number]',
-  perPage: 'page[size]',
+  pagination: {
+    page: 'page[number]',
+    perPage: 'page[size]',
+  },
   headers: {
     Accept: 'application/vnd.api+json; charset=utf-8',
     'Content-Type': 'application/vnd.api+json; charset=utf-8',

--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -1,5 +1,7 @@
 export default {
   total: 'total',
+  page: 'page[number]',
+  perPage: 'page[size]',
   headers: {
     Accept: 'application/vnd.api+json; charset=utf-8',
     'Content-Type': 'application/vnd.api+json; charset=utf-8',

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,8 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       // Create query with pagination params.
       const query = {
-        'page[number]': page,
-        'page[size]': perPage,
+        [settings.page]: page,
+        [settings.perPage]: perPage,
       };
 
       // Add all filter params to query.
@@ -108,8 +108,8 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       // Create query with pagination params.
       const query = {
-        'page[number]': page,
-        'page[size]': perPage,
+        [settings.page]: page,
+        [settings.perPage]: perPage,
       };
 
       // Add all filter params to query.

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,8 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       // Create query with pagination params.
       const query = {
-        [settings.page]: page,
-        [settings.perPage]: perPage,
+        [settings.pagination.page]: page,
+        [settings.pagination.perPage]: perPage,
       };
 
       // Add all filter params to query.
@@ -108,8 +108,8 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       // Create query with pagination params.
       const query = {
-        [settings.page]: page,
-        [settings.perPage]: perPage,
+        [settings.pagination.page]: page,
+        [settings.pagination.perPage]: perPage,
       };
 
       // Add all filter params to query.


### PR DESCRIPTION
As per [https://jsonapi.org/format/#auto-id--pagination](https://jsonapi.org/format/#auto-id--pagination)

> Note: JSON:API is agnostic about the pagination strategy used by a server. Effective pagination strategies include (but are not limited to): page-based, offset-based, and cursor-based. The page query parameter can be used as a basis for any of these strategies. For example, a page-based strategy might use query parameters such as page[number] and page[size], an offset-based strategy might use page[offset] and page[limit], while a cursor-based strategy might use page[cursor]

This PR will allow us to customize the query name depending on the server's spec.