### PR TITLE
Support for JSON API servers that don't return a total

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Which will work for:
 ```
 If this option is not set it will fall back to `total`.
 
+In addition, if your server doesn't provide a count field, you can set *total count* to `null`, and the provider will
+assume the total count is the same as the length of the data array:
+
+``` javascript
+const dataProvider = jsonapiClient('http://localhost:3000', { total: null });
+```
+
 ### Custom HTTP headers
 Custom headers can be set by providing a `headers` object in `options`:
 

--- a/test/fixtures/get-list-no-meta.js
+++ b/test/fixtures/get-list-no-meta.js
@@ -1,0 +1,19 @@
+export default {
+  data: [
+    {
+      type: 'user', id: 1, attributes: { name: 'Bob' },
+    },
+    {
+      type: 'user', id: 2, attributes: { name: 'Alice' },
+    },
+    {
+      type: 'user', id: 3, attributes: { name: 'Harry' },
+    },
+    {
+      type: 'user', id: 4, attributes: { name: 'Zoe' },
+    },
+    {
+      type: 'user', id: 5, attributes: { name: 'Jack' },
+    },
+  ]
+};

--- a/test/index.js
+++ b/test/index.js
@@ -226,3 +226,37 @@ describe('GET_MANY', () => {
     expect(result).to.have.property('total').that.is.equal(1);
   });
 });
+
+// This test should work exactly the same as the normal GET_LIST test, but the returned data has no
+// meta  field, and thus no count variable. We set the count variable to null in the client
+describe("GET_LIST with {total: null}", () => {
+  it("contains a total property", () => {
+    nock("http://api.example.com")
+      .get(/users.*sort=name.*/)
+      .reply(200, getListNoMeta)
+
+    const noMetaClient = jsonapiClient("http://api.example.com", {
+      total: null
+    })
+
+    return expect(
+      noMetaClient("GET_LIST", "users", {
+        pagination: {page: 1, perPage: 25},
+        sort: {field: "name", order: "ASC"}
+      })
+    ).to.eventually.have.property("total").that.is.equal(5)
+  })
+});
+
+describe("GET_LIST with incorrect \"total\"", () => {
+  it("throws an Error in this situation", () => {
+    nock("http://api.example.com")
+      .get(/users.*sort=name.*/)
+      .reply(200, getListNoMeta)
+
+    return expect(client("GET_LIST", "users", {
+      pagination: {page: 1, perPage: 25},
+      sort: {field: "name", order: "ASC"}
+    })).to.be.rejectedWith(Error)
+  })
+});

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import jsonapiClient from '../src/index';
 import getList from './fixtures/get-list';
+import getListNoMeta from './fixtures/get-list-no-meta';
 import getManyReference from './fixtures/get-many-reference';
 import getOne from './fixtures/get-one';
 import create from './fixtures/create';


### PR DESCRIPTION
Closes #18

Basically this lets you do:
```js
const dataProvider = jsonapiClient('http://localhost:3000', { total: null });
```