### PR TITLE
Use jsonapi-serializer instead of a custom one

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,33 @@ This package makes usage of the aweseome `qs` querystring parsing library.
 Default: `brackets`
 Options: `indices`, `repeat`, `comma`
 
+### Resource-specific serialization
+Since `ra-jsonapi-client` internally uses
+[`jsonapi-serializer`](https://github.com/SeyZ/jsonapi-serializer), you can pass serialization
+options to the serializer using the `serializerOpts` option. This field is itself a dictionary
+that maps resource names to
+[serialization options](https://github.com/SeyZ/jsonapi-serializer#available-serialization-option-opts-argument)
+to use for that resource. You can think of these options as a bit like schemas that describe how
+to serialize that resource.
+
+For example, if you have a `user` resource that has a relationship
+to an `address` resource, you probably want its address attribute to be serialized as a JSON API
+relationship, not just as a regular field. To do that, you might create an options object like this:
+```javascript
+{
+    serializerOpts: {
+        // Options for all "user" resources
+        user: {
+            // Options for the "address" field on a "user"
+            address: {
+                // The ID of an address is given by its id field
+                ref: (user, address) => address.id
+            }
+        }
+    }
+}
+```
+
 ## Contributors
 * [TMiguelT](https://github.com/TMiguelT)
 * [hootbah](https://github.com/hootbah)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "deepmerge": "^2.1.1",
+    "jsonapi-serializer": "^3.6.5",
     "qs": "^6.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^5.5.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
+    "lodash.matches": "^4.6.0",
     "mocha": "^5.2.0",
     "mock-local-storage": "^1.1.7",
     "nock": "^10.0.0",

--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -6,5 +6,5 @@ export default {
   },
   updateMethod: 'PATCH',
   arrayFormat: 'brackets',
-  serializerOpts: {}
+  serializerOpts: {},
 };

--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -7,4 +7,5 @@ export default {
   updateMethod: 'PATCH',
   arrayFormat: 'brackets',
   serializerOpts: {},
+  deserializerOpts: {},
 };

--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -6,4 +6,5 @@ export default {
   },
   updateMethod: 'PATCH',
   arrayFormat: 'brackets',
+  serializerOpts: {}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,15 @@ const relationshipProxyHandler = {
     return true;
   },
   get(target, key) {
+    const fallback = target[key];
+
+    // Use the fallback for special options
     if (specialOpts.includes(key)) {
-      return target[key];
+      return fallback;
     }
 
-    return {
+    // Merge the fallback with this object for per-resource settings
+    return Object.assign({
       valueForRelationship(data, included) {
         // If we have actual included data use it, but otherwise just return the id in an object
         if (included) {
@@ -36,7 +40,7 @@ const relationshipProxyHandler = {
 
         return { id: data.id };
       },
-    };
+    }, fallback || {});
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import init from './initializer';
 /** This proxy ensures that every relationship is serialized to an object of the form {id: x}, even
  * if that relationship doesn't have included data
  */
-const specialOpts = ['transform', 'keyForAttribute', 'id', 'typeAsAttribute'];
+const specialOpts = [ 'transform', 'keyForAttribute', 'id', 'typeAsAttribute' ];
 const relationshipProxy = new Proxy({}, {
   has(target, key) {
     // Pretend to have all keys except certain ones with special meanings
@@ -59,6 +59,12 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
     headers: settings.headers,
   };
 
+  function getSerializerOpts() {
+    return Object.assign({
+      attributes: Object.keys(params.data),
+    }, settings.serializerOpts);
+  }
+
   switch (type) {
     case GET_LIST: {
       const { page, perPage } = params.pagination;
@@ -91,9 +97,7 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
     case CREATE:
       url = `${apiUrl}/${resource}`;
       options.method = 'POST';
-      options.data = new Serializer(resource, {
-        attributes: Object.keys(params.data),
-      }).serialize(params.data);
+      options.data = new Serializer(resource, getSerializerOpts()).serialize(params.data);
       break;
 
     case UPDATE: {
@@ -102,9 +106,7 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
       const data = Object.assign({ id: params.id }, params.data);
 
       options.method = settings.updateMethod;
-      options.data = new Serializer(resource, {
-        attributes: Object.keys(params.data),
-      }).serialize(data);
+      options.data = new Serializer(resource, getSerializerOpts()).serialize(data);
       break;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,9 +63,10 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
   };
 
   function getSerializerOpts() {
+    const resourceSpecific = settings.serializerOpts[resource] || {};
     return Object.assign({
       attributes: Object.keys(params.data),
-    }, settings.serializerOpts);
+    }, resourceSpecific);
   }
 
   switch (type) {
@@ -154,7 +155,7 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
   return axios({ url, ...options })
     .then((response) => {
-      const opts = new Proxy(settings.deserializerOpts, relationshipProxyHandler);
+      const opts = new Proxy(settings.deserializerOpts[resource] || {}, relationshipProxyHandler);
 
       switch (type) {
         case GET_MANY:

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import init from './initializer';
 /** This proxy ensures that every relationship is serialized to an object of the form {id: x}, even
  * if that relationship doesn't have included data
  */
-const specialOpts = [ 'transform', 'keyForAttribute', 'id', 'typeAsAttribute' ];
+const specialOpts = ['transform', 'keyForAttribute', 'id', 'typeAsAttribute'];
 const relationshipProxy = new Proxy({}, {
   has(target, key) {
     // Pretend to have all keys except certain ones with special meanings

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import init from './initializer';
 /** This proxy ensures that every relationship is serialized to an object of the form {id: x}, even
  * if that relationship doesn't have included data
  */
-const specialOpts = ['transform', 'keyForAttribute', 'id', 'typeAsAttribute'];
+const specialOpts = ['transform', 'keyForAttribute', 'id', 'typeAsAttribute', 'links'];
 const relationshipProxyHandler = {
   has(target, key) {
     // Pretend to have all keys except certain ones with special meanings
@@ -68,8 +68,14 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
   function getSerializerOpts() {
     const resourceSpecific = settings.serializerOpts[resource] || {};
+
+    // By default, assume the user wants to serialize all keys except links, in case that's
+    // a leftover from a deserialized resource
+    const attributes = new Set(Object.keys(params.data));
+    attributes.delete('links');
+
     return Object.assign({
-      attributes: Object.keys(params.data),
+      attributes: [...attributes],
     }, resourceSpecific);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,6 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
       url = `${apiUrl}/${resource}`;
       options.method = 'POST';
       options.data = new Serializer(resource, { attributes: Object.keys(params.data) }).serialize(params.data);
-      // options.data = JSON.stringify({
-      //   data: { type: resource, attributes: params.data },
-      // });
       break;
 
     case UPDATE: {
@@ -112,7 +109,6 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       options.method = settings.updateMethod;
       options.data = new Serializer(resource, { attributes: Object.keys(params.data) }).serialize(data);
-      // options.data = JSON.stringify(data);
       break;
     }
 

--- a/src/initializer.js
+++ b/src/initializer.js
@@ -31,12 +31,12 @@ export default () => {
   // Response interceptor
   axios.interceptors.response.use(
     response => response,
-    (error) => {
-      const { status, data } = error.response;
+    error => {
+      const { status, message } = error;
 
       if (status < 200 || status >= 300) {
         return Promise.reject(
-          new HttpError(data, status),
+          new HttpError(message, status),
         );
       }
 

--- a/src/initializer.js
+++ b/src/initializer.js
@@ -31,7 +31,7 @@ export default () => {
   // Response interceptor
   axios.interceptors.response.use(
     response => response,
-    error => {
+    (error) => {
       const { status, message } = error;
 
       if (status < 200 || status >= 300) {

--- a/test/fixtures/get-many-relationship-included.js
+++ b/test/fixtures/get-many-relationship-included.js
@@ -1,0 +1,29 @@
+export default {
+  data: [
+    {
+      type: 'user',
+      id: 1,
+      attributes: { name: 'Bob' },
+      relationships: {
+        address: {
+          data: { type: 'address', id: '9' }
+        }
+      }
+    },
+  ],
+  meta: {
+    'total-count': 1,
+  },
+  included: [
+    {
+      type: 'address',
+      id: '9',
+      attributes: {
+        street: 'Pinchelone Street',
+        number: 2475,
+        city: 'Norfolk',
+        state: 'VA'
+      }
+    }
+  ]
+};

--- a/test/fixtures/get-one-data-links.js
+++ b/test/fixtures/get-one-data-links.js
@@ -1,0 +1,15 @@
+export default {
+  data: {
+    type: 'user',
+    id: '1',
+    attributes: {
+      name: 'Bob',
+    },
+    links: {
+      self: '/user/1',
+    },
+  },
+  links: {
+    related: '/user/1',
+  },
+};

--- a/test/fixtures/get-one-relationship-included.js
+++ b/test/fixtures/get-one-relationship-included.js
@@ -7,14 +7,14 @@ export default {
     },
     relationships: {
       address: {
-        data: { type: 'address', id: '9' }
+        data: { type: 'address', id: '2' }
       }
     }
   },
   included: [
     {
       type: 'address',
-      id: '9',
+      id: '2',
       attributes: {
         street: 'Pinchelone Street',
         number: 2475,

--- a/test/fixtures/get-one-relationship-included.js
+++ b/test/fixtures/get-one-relationship-included.js
@@ -1,0 +1,26 @@
+export default {
+  data: {
+    type: 'user',
+    id: 1,
+    attributes: {
+      name: 'Bob',
+    },
+    relationships: {
+      address: {
+        data: { type: 'address', id: '9' }
+      }
+    }
+  },
+  included: [
+    {
+      type: 'address',
+      id: '9',
+      attributes: {
+        street: 'Pinchelone Street',
+        number: 2475,
+        city: 'Norfolk',
+        state: 'VA'
+      }
+    }
+  ]
+};

--- a/test/fixtures/get-one-relationship-included.js
+++ b/test/fixtures/get-one-relationship-included.js
@@ -1,7 +1,7 @@
 export default {
   data: {
     type: 'user',
-    id: 1,
+    id: '1',
     attributes: {
       name: 'Bob',
     },

--- a/test/fixtures/get-one-relationship-linkage.js
+++ b/test/fixtures/get-one-relationship-linkage.js
@@ -7,7 +7,7 @@ export default {
     },
     relationships: {
       address: {
-        data: { type: 'address', id: '9' }
+        data: { type: 'address', id: '2' }
       }
     }
   }

--- a/test/fixtures/get-one-relationship-linkage.js
+++ b/test/fixtures/get-one-relationship-linkage.js
@@ -1,0 +1,14 @@
+export default {
+  data: {
+    type: 'user',
+    id: 1,
+    attributes: {
+      name: 'Bob',
+    },
+    relationships: {
+      address: {
+        data: { type: 'address', id: '9' }
+      }
+    }
+  }
+};

--- a/test/fixtures/get-one-relationship-linkage.js
+++ b/test/fixtures/get-one-relationship-linkage.js
@@ -1,7 +1,7 @@
 export default {
   data: {
     type: 'user',
-    id: 1,
+    id: '1',
     attributes: {
       name: 'Bob',
     },

--- a/test/fixtures/get-one-relationship-links.js
+++ b/test/fixtures/get-one-relationship-links.js
@@ -1,0 +1,16 @@
+export default {
+  data: {
+    type: 'user',
+    id: 1,
+    attributes: {
+      name: 'Bob',
+    },
+    relationships: {
+      cars: {
+        'links': {
+          'related': '/users/1/cars',
+        },
+      }
+    }
+  }
+};

--- a/test/fixtures/get-one-relationship-links.js
+++ b/test/fixtures/get-one-relationship-links.js
@@ -1,14 +1,14 @@
 export default {
   data: {
     type: 'user',
-    id: 1,
+    id: '1',
     attributes: {
       name: 'Bob',
     },
     relationships: {
       cars: {
-        'links': {
-          'related': '/users/1/cars',
+        links: {
+          related: '/users/1/cars',
         },
       }
     }

--- a/test/fixtures/get-one.js
+++ b/test/fixtures/get-one.js
@@ -1,7 +1,7 @@
 export default {
   data: {
     type: 'user',
-    id: 1,
+    id: '1',
     attributes: {
       name: 'Bob',
     },

--- a/test/index.js
+++ b/test/index.js
@@ -125,10 +125,10 @@ describe('GET_MANY_REFERENCE', () => {
 [
   [ 'simple', getOne, {} ],
   [ 'links only', getOneLinks, {} ],
-  [ 'resource linkage', getOneLinkage, { address: { id: '9' } } ],
+  [ 'resource linkage', getOneLinkage, { address: { id: '2' } } ],
   [ 'included data', getOneIncluded, {
     address: {
-      id: '9',
+      id: '2',
       street: 'Pinchelone Street',
       number: 2475,
       city: 'Norfolk',

--- a/test/index.js
+++ b/test/index.js
@@ -155,7 +155,7 @@ describe('GET_MANY_REFERENCE', () => {
     });
 
     it('has record ID', () => {
-      expect(result.data).to.have.property('id').that.is.equal(1);
+      expect(result.data).to.have.property('id').that.is.equal('1');
     });
 
     it('has records attributes', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ import getOne from './fixtures/get-one';
 import getOneLinkage from './fixtures/get-one-relationship-linkage';
 import getOneIncluded from './fixtures/get-one-relationship-included';
 import getOneLinks from './fixtures/get-one-relationship-links';
+import getOneDataLinks from './fixtures/get-one-data-links';
 import create from './fixtures/create';
 import update from './fixtures/update';
 import getMany from './fixtures/get-many';
@@ -50,6 +51,9 @@ function addIds(url, req) {
 }
 
 describe('GET_LIST', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   beforeEach(() => {
     nock('http://api.example.com')
       .get(/users.*sort=name.*/)
@@ -86,6 +90,9 @@ describe('GET_LIST', () => {
 });
 
 describe('GET_MANY_REFERENCE', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   beforeEach(() => {
     nock('http://api.example.com')
       .get(/users.*company_id.*=1/)
@@ -138,6 +145,9 @@ describe('GET_MANY_REFERENCE', () => {
   ],
 ].map(([key, response, relationships]) => {
   describe(`GET_ONE "${key}"`, () => {
+    after(() => {
+      nock.cleanAll();
+    });
 
     beforeEach(() => {
       nock('http://api.example.com')
@@ -168,6 +178,31 @@ describe('GET_MANY_REFERENCE', () => {
   });
 });
 
+describe('CREATE with data links', () => {
+  after(() => {
+    nock.cleanAll();
+  });
+
+  it('does not include the links object in the serialized result', () => {
+    // (links are only for the JSON API serialized form)
+    nock('http://api.example.com')
+      .post('/users', (body) => {
+        return !('links' in body.data.attributes);
+      })
+      .reply(201, addIds);
+
+    return client('CREATE', 'users', {
+      data: {
+        name: 'Bob',
+        id: 1,
+        links: {
+          self: '/user/1',
+        },
+      },
+    });
+  });
+});
+
 [
   [
     'simple',
@@ -194,6 +229,9 @@ describe('GET_MANY_REFERENCE', () => {
   ],
 ].map(([key, serialized, unserialized]) => {
   describe(`CREATE ${key}`, () => {
+    after(() => {
+      nock.cleanAll();
+    });
     beforeEach(() => {
       nock('http://api.example.com')
         .post('/users', body => {
@@ -238,6 +276,9 @@ describe('GET_MANY_REFERENCE', () => {
 });
 
 describe('UPDATE', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   beforeEach(() => {
     nock('http://api.example.com')
       .patch('/users/1')
@@ -263,6 +304,9 @@ describe('UPDATE', () => {
 });
 
 describe('DELETE', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   beforeEach(() => {
     nock('http://api.example.com')
       .delete('/users/1')
@@ -290,6 +334,9 @@ describe('UNDEFINED', () => {
 });
 
 describe('Unauthorized request', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   beforeEach(() => {
     nock('http://api.example.com').get('/users/1').reply(401);
   });
@@ -316,6 +363,9 @@ describe('Unauthorized request', () => {
   ],
 ].map(([key, response, relationships]) => {
   describe(`GET_MANY "${key}"`, () => {
+    after(() => {
+      nock.cleanAll();
+    });
     beforeEach(() => {
       nock('http://api.example.com')
         .get('/users')
@@ -358,6 +408,9 @@ describe('Unauthorized request', () => {
 // returned data has no meta field, and thus no count variable. We set the
 // count variable to null in the client
 describe('GET_LIST with {total: null}', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   it('contains a total property', () => {
     nock('http://api.example.com')
       .get(/users.*sort=name.*/)
@@ -375,6 +428,9 @@ describe('GET_LIST with {total: null}', () => {
 });
 
 describe('CREATE with custom serializerOpts and deserializerOpts', () => {
+  after(() => {
+    nock.cleanAll();
+  });
   it('loads an underscore_case relationship, and deserializes it to CamelCase', () => {
     nock('http://api.example.com')
       .post('/data')

--- a/test/index.js
+++ b/test/index.js
@@ -382,13 +382,17 @@ describe('CREATE with custom serializerOpts and deserializerOpts', () => {
 
     const underscoreClient = jsonapiClient('http://api.example.com', {
       serializerOpts: {
-        keyForAttribute: 'underscore_case',
-        data_type: {
-          ref: (outer, inner) => inner.id,
+        data: {
+          keyForAttribute: 'underscore_case',
+          data_type: {
+            ref: (outer, inner) => inner.id,
+          },
         },
       },
       deserializerOpts: {
-        keyForAttribute: 'CamelCase',
+        data: {
+          keyForAttribute: 'CamelCase',
+        },
       },
     });
 


### PR DESCRIPTION
This PR makes the client use the popular jsonapi serializer/deserializer [`jsonapi-serializer`](https://github.com/SeyZ/jsonapi-serializer) instead of our own one. This gives this client much more power for free, including us the ability to deserialize and serialize relationships/included data, and it actually makes the codebase a lot simpler! Thus, this closes #20, and replaces #22.

Yes, `jsonapi-serializer` does have some issues (it's infrequently maintained, sadly), but there's nothing actually wrong with it, just some missing features. It's still a solid step up from the existing parsing logic we had.

I've added a bunch of tests for this, based on #22, all of which pass!