### PR TITLE
Adding support for the X-Total-Count header

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Which will work for:
 ```
 If this option is not set it will fall back to `total`.
 
-In addition, if your server doesn't provide a count field, you can set *total
+If your server supports the `X-Total-Count` header, and this header is sent on the response, then this will be used in preference to any *total key/value* found in the meta object.
+
+In addition, if your server doesn't provide either the `X-Total-Count` header or provide a count field in the meta object, then you can set *total
 count* to `null`, and the provider will assume the total count is the same as
 the length of the data array:
 

--- a/src/index.js
+++ b/src/index.js
@@ -144,9 +144,9 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
       // For all collection requests get the total count.
       if ([GET_LIST, GET_MANY, GET_MANY_REFERENCE].includes(type)) {
-        // When meta data and the 'total' setting is provided try
-        // to get the total count.
-        if (response.data.meta && settings.total) {
+        if ('x-total-count' in response.headers) {
+          total = parseInt(response.headers['x-total-count']);
+        } else if (response.data.meta && settings.total) {
           total = response.data.meta[settings.total];
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -248,3 +248,33 @@ describe('GET_LIST with {total: null}', () => {
     })).to.eventually.have.property('total').that.is.equal(5);
   });
 });
+
+describe('GET_LIST with {total: null} and X-Total-Count header', () => {
+  it('contains total property with X-Total-Count value', () => {
+      nock('http://api.example.com')
+        .get(/users.*sort=name.*/)
+        .reply(200, getListNoMeta, {'X-Total-Count': 200});
+  
+      const noMetaClient = jsonapiClient('http://api.example.com', {
+        total: null,
+      });
+  
+      return expect(noMetaClient('GET_LIST', 'users', {
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: 'name', order: 'ASC' },
+      })).to.eventually.have.property('total').that.is.equal(200);
+  });
+});
+
+describe('GET_LIST with meta and X-Total-Count header', () => {
+  it('contains total property using X-Total-Count in preference to meta value', () => {
+      nock('http://api.example.com')
+        .get(/users.*sort=name.*/)
+        .reply(200, getListNoMeta, {'X-Total-Count': 200});
+  
+      return expect(client('GET_LIST', 'users', {
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: 'name', order: 'ASC' },
+      })).to.eventually.have.property('total').that.is.equal(200);
+  });
+});


### PR DESCRIPTION

I have been attempting to get a golang server utilising jsonapi (https://github.com/google/jsonapi) to work with react-admin using this data provider and got stuck on how to communicate the total number of records. The way in which the structures are marshalled makes it impossible to try to add meta objects to collections. (if i'm mistaken, i'd be very happy if someone could share a code snippet with me). As such, the alternate approach was to make use of the `X-Total-Count` header, which is trivial to add on the server side and trivial to process on the client side.





