### PR TITLE
Introduce new setting getManyKey, which allows to modify query key 'filter[id]'

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ This package makes usage of the aweseome `qs` querystring parsing library.
 Default: `brackets`
 Options: `indices`, `repeat`, `comma`
 
+### Key for `GET_MANY` filter
+In most cases `filter[id]` is enough for get many operation.
+But it is not a specification of JSONAPI.
+You can change this key `id` to any string.
+
+``` javascript
+{
+  // When your api requires filter[id_in] for get many operation.
+  getManyKey: 'id_in'
+}
+```
+
+Default: `id`
+
 ## Contributors
 * [TMiguelT](https://github.com/TMiguelT)
 * [hootbah](https://github.com/hootbah)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-jsonapi-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "JSON API data provider for react-admin.",
   "main": "build/index.js",
   "scripts": {

--- a/src/default-settings.js
+++ b/src/default-settings.js
@@ -6,4 +6,5 @@ export default {
   },
   updateMethod: 'PATCH',
   arrayFormat: 'brackets',
+  getManyKey: 'id',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
 
     case GET_MANY: {
       const query = stringify({
-        'filter[id]': params.ids,
+        [`filter[${settings.getManyKey}]`]: params.ids,
       }, { arrayFormat: settings.arrayFormat });
 
       url = `${apiUrl}/${resource}?${query}`;


### PR DESCRIPTION
In some api server, `filter[id]` is not suitable for get many operations. In detail, my request should be like '`filter[id_in]=1,2,3,4`' Also, this doesn't violate JSON API protocol. JSON API only specifies 'filter' key. https://jsonapi.org/format/#fetching-filtering