### PR TITLE
feat: nested total count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,9 +147,15 @@ export default (apiUrl, userSettings = {}) => (type, resource, params) => {
         // When meta data and the 'total' setting is provided try
         // to get the total count.
         if (response.data.meta && settings.total) {
-          total = response.data.meta[settings.total];
+          if (Array.isArray(settings.total)) {
+            total = response.data.meta;
+            settings.total.forEach((setting) => {
+              total = total[setting];
+            });
+          } else {
+            total = response.data.meta[settings.total];
+          }
         }
-
         // Use the length of the data array as a fallback.
         total = total || response.data.data.length;
       }

--- a/test/fixtures/get-list-nested-count.js
+++ b/test/fixtures/get-list-nested-count.js
@@ -1,0 +1,22 @@
+export default {
+  data: [
+    {
+      type: 'user', id: 1, attributes: { name: 'Bob' },
+    },
+    {
+      type: 'user', id: 2, attributes: { name: 'Alice' },
+    },
+    {
+      type: 'user', id: 3, attributes: { name: 'Harry' },
+    },
+    {
+      type: 'user', id: 4, attributes: { name: 'Zoe' },
+    },
+    {
+      type: 'user', id: 5, attributes: { name: 'Jack' },
+    },
+  ],
+  meta: {
+    cursor: { 'total-count': 5 },
+  },
+};

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ import getOne from './fixtures/get-one';
 import create from './fixtures/create';
 import update from './fixtures/update';
 import getMany from './fixtures/get-many';
+import getListNestedCount from './fixtures/get-list-nested-count';
 
 chai.use(chaiAsPromised);
 
@@ -240,6 +241,23 @@ describe('GET_LIST with {total: null}', () => {
 
     const noMetaClient = jsonapiClient('http://api.example.com', {
       total: null,
+    });
+
+    return expect(noMetaClient('GET_LIST', 'users', {
+      pagination: { page: 1, perPage: 25 },
+      sort: { field: 'name', order: 'ASC' },
+    })).to.eventually.have.property('total').that.is.equal(5);
+  });
+});
+
+describe('GET_LIST with nested total count', () => {
+  it('contains a total property', () => {
+    nock('http://api.example.com')
+      .get(/users.*sort=name.*/)
+      .reply(200, getListNestedCount);
+
+    const noMetaClient = jsonapiClient('http://api.example.com', {
+      total: ['cursor', 'total-count'],
     });
 
     return expect(noMetaClient('GET_LIST', 'users', {


### PR DESCRIPTION
In our pagination we have the 'total-count' for a list nested in a cursor object like
```
{
    data: {...},
    meta: {
        cursor: {
            total-count: 1234
        }
    }
}
```

This PR adds support for a nested total count and closes #40 